### PR TITLE
fix: downgrade riverpod_generator for isar compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dev_dependencies:
   build_runner: ^2.4.13
   freezed: ^2.4.0
   json_serializable: ^6.8.0
-  riverpod_generator: ^2.6.1
+  riverpod_generator: ^2.4.0
   isar_generator: ^3.1.0+1
 
 flutter:


### PR DESCRIPTION
## Problem
`riverpod_generator ^2.6.1` is incompatible with `isar_generator ^3.1.0+1` due to analyzer version conflicts.

## Solution
Downgrade `riverpod_generator` to `^2.4.0` to resolve the dependency conflict.

## Changes
- `pubspec.yaml`: `riverpod_generator: ^2.6.1` → `^2.4.0`

This follows Flutter/Dart best practices for managing transitive analyzer dependencies.